### PR TITLE
Add environment line into Puppet client template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,8 @@
 #
 # [*server*]
 #
+# [*environment*]
+#
 # [*allow*]
 #
 # [*bindaddress*]
@@ -288,6 +290,7 @@
 class puppet (
   $mode                = params_lookup( 'mode' ),
   $server              = params_lookup( 'server' ),
+  $environment         = params_lookup( 'environment' ),
   $allow               = params_lookup( 'allow' ),
   $bindaddress         = params_lookup( 'bindaddress' ),
   $listen              = params_lookup( 'listen' ),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class puppet::params {
     ''      => 'puppet',
     default => "puppet.$::domain",
   }
+  $environment = 'production',
   $allow = $::domain ? {
     ''      => [ '127.0.0.1' ],
     default => [ "*.$::domain" , '127.0.0.1' ],

--- a/templates/client/puppet.conf.erb
+++ b/templates/client/puppet.conf.erb
@@ -16,6 +16,7 @@
 <% if scope.lookupvar('puppet::params::major_version') == "0.2" -%>[puppetd]<% else -%>[agent]<% end %>
   certname = <%= scope.lookupvar('clientcert') %>
   server = <%= scope.lookupvar('puppet::server') %>
+  environment = <%= scope.lookupvar('puppet::environment') %>
   pluginsync = true
   report = true
   reportserver = <%= scope.lookupvar('puppet::server') %>


### PR DESCRIPTION
Hi, I thought someone might find this useful if they're using different environments.. Not sure if you want to specify 'production' as the environment by default, but that is the standard puppet default anyway.
