### PR TITLE
ENH: manage puppetd startup on debianesque systems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,6 +283,9 @@
 #   This is used by monitor, firewall and puppi (optional) components
 #   Can be defined also by the (top scope) variable $puppet_protocol
 #
+# [*client_daemon_opts*]
+#   If $operatingsystem is Debian or Ubuntu, these options will be passed to
+#   the puppetd on startup
 #
 # == Examples
 #
@@ -378,7 +381,8 @@ class puppet (
   $log_dir             = params_lookup( 'log_dir' ),
   $log_file            = params_lookup( 'log_file' ),
   $port                = params_lookup( 'port' ),
-  $protocol            = params_lookup( 'protocol' )
+  $protocol            = params_lookup( 'protocol' ),
+  $client_daemon_opts  = params_lookup( 'client_daemon_opts' )
   ) inherits puppet::params {
 
   $bool_listen=any2bool($listen)
@@ -564,8 +568,7 @@ class puppet (
 
   # Enable service start on Ubuntu
   if ($::operatingsystem == 'Ubuntu'
-  or $::operatingsystem == 'Debian')
-  and $puppet::runmode == 'service' {
+  or $::operatingsystem == 'Debian') {
     file { 'default-puppet':
       ensure  => $puppet::manage_file,
       path    => $puppet::config_file_init,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -181,6 +181,8 @@ class puppet::params {
   $port = '8140'
   $protocol = 'tcp'
 
+  $client_daemon_opts = ''
+
   # General Settings
   $my_class = ''
   $source = ''

--- a/templates/default.init-ubuntu
+++ b/templates/default.init-ubuntu
@@ -3,7 +3,7 @@
 # Defaults for puppet - sourced by /etc/init.d/puppet
 
 # Start puppet on boot?
-START=yes
+START=<% if scope.lookupvar('puppet::runmode') == 'service' and scope.lookupvar('puppet::mode') == 'client' -%>yes<% else %>no<% end %> 
 
 # Startup options
-DAEMON_OPTS=""
+DAEMON_OPTS="<%= scope.lookupvar('puppet::client_daemon_opts') -%>"


### PR DESCRIPTION
This PR manages the `/etc/default/puppet` config file in a more sensible way: On debianesque systems, puppet will set `START=yes` only if `runmode==server` and `START=no` otherwise. Current behavior will leave the config file untouched if `runmode!=server`. This is problematic in cases where `START=yes` is set by a provitioning process before the node gets managed by puppet, and you have `runmode=cron` in your config.

The new behaviour will disable puppetd in these cases.

Additionally, a new config parameter `client_daemon_opts` is introduced which sets the `DAEMON_OPTS` parameter in the config file.
