### PR TITLE
ENH: set masterport in client's and server's puppet.conf

### DIFF
--- a/templates/client/puppet.conf.erb
+++ b/templates/client/puppet.conf.erb
@@ -9,6 +9,8 @@
   user = <%= scope.lookupvar('puppet::process_user') %>
   group = <%= scope.lookupvar('puppet::process_user') %>
 
+  masterport = <%= scope.lookupvar('puppet::port') %>
+
 <% if scope.lookupvar('puppet::prerun_command') != '' -%>
   prerun_command = "<%= scope.lookupvar('puppet::prerun_command') -%>"
 <% end -%>

--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -31,6 +31,7 @@
   localconfig = $vardir/localconfig
 
 <% if scope.lookupvar('puppet::params::major_version') == "0.2" -%>[puppetmasterd]<% else -%>[master]<% end %>
+  masterport = <%= scope.lookupvar('puppet::port') %>
 <% if scope.lookupvar('puppet::bindaddress') != '' -%>
   bindaddress = <%= scope.lookupvar('puppet::bindaddress') %>
 <% end -%>


### PR DESCRIPTION
To allow puppetmaster to run (and be heard) on a non-standard port, I added `masterport = $port`-like stanzas to both server's and client's `puppet.conf`.
