### PR TITLE
Made sure, the ruby sqlite3 package is installed when the default DB configuration is used.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -232,6 +232,22 @@ class puppet::params {
     default                                 => 'libmysql-ruby',
   }
 
+  $sqlite_package = $::osfamily ? {
+    #/(?i:RedHat)/ => '# TODO: find the right package name on RH based distributions',
+    /Debian/    => 'ruby-sqlite3',
+    /Gentoo/    => 'dev-ruby/sqlite3',
+    /(?i:SuSE)/ => $::operatingsystem ? {
+        /(?:OpenSuSE)/ => 'rubygem-sqlite3',
+        default        => 'sqlite3-ruby',
+    },
+    # older Facter versions don't report a Gentoo OS family
+    /Linux/     => $::operatingsystem ? {
+        /Gentoo/ => 'dev-ruby/sqlite3',
+        default  => 'sqlite3-ruby',
+    },
+    default     => 'sqlite3-ruby',
+  }
+
   # General Settings
   $my_class = ''
   $source = ''

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -88,7 +88,7 @@ class puppet::server inherits puppet {
   case $puppet::db {
     mysql: { include puppet::server::mysql }
     puppetdb: { include puppet::server::puppetdb }
-    default: { }
+    default: { include puppet::server::sqlite }
   }
 
   ### Manage Passenger

--- a/manifests/server/sqlite.pp
+++ b/manifests/server/sqlite.pp
@@ -1,0 +1,12 @@
+# Class puppet::server::sqlite
+#
+# Manages sqlite on Puppet Master.
+#
+class puppet::server::sqlite {
+
+  require puppet
+
+  package { $puppet::sqlite_package:
+    ensure => present,
+  }
+}


### PR DESCRIPTION
Until now, one could run into a situation like this:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: cannot load such file -- sqlite3
```

This PR fixes this by making sure, the Ruby sqlite3 package is installed when sqlite is used for the DB configuration (which is the default case).

As I don't have access to any RedHat box and the RedHat package index is only to RHN members, I can't tell for sure, what's the right package name on RedHat based distributions, so I left this line commented as TODO.

This is a proper/rebased followup to the messed up #52
