### PR TITLE
Removed non-ASCII whitespace which somehow ended up in manifest/ninit.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -614,7 +614,7 @@ class puppet (
     require    => Package['puppet'],
   }
 
-  # Enable service start on Ubuntu
+  # Enable service start on Ubuntu
   if ($::operatingsystem == 'Ubuntu'
   or $::operatingsystem == 'Debian') {
     file { 'default-puppet':


### PR DESCRIPTION
manifests/init.pp contained a non-ASCII whitespace in line 617 which caused [PL#20897](http://projects.puppetlabs.com/issues/20897).
Replaced that with a proper whitespace, now the file is plain ASCII again.

Before:

```
file manifests/init.pp
manifests/init.pp: C++ source, UTF-8 Unicode text
```

Now:

```
file manifests/init.pp
manifests/init.pp: C++ source, ASCII text
```
