### PR TITLE
Adding OracleLinux Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,7 +109,7 @@ class puppet::params {
   $service_server_autorestart = false
 
   $basedir = $::operatingsystem ? {
-    /(?i:RedHat|Centos|Scientific|Fedora)/ => '/usr/lib/ruby/site_ruby/1.8/puppet',
+    /(?i:RedHat|Centos|Scientific|Fedora|Linux)/ => '/usr/lib/ruby/site_ruby/1.8/puppet',
     default                                => '/usr/lib/ruby/1.8/puppet',
   }
 
@@ -151,7 +151,7 @@ class puppet::params {
   $process = $major_version ? {
     '0.2' => 'puppetd',
     '2.x' => $::operatingsystem ? {
-      /(?i:RedHat|Centos|Scientific|Fedora)/ => 'puppetd',
+      /(?i:RedHat|Centos|Scientific|Fedora|Linux)/ => 'puppetd',
       default                                => 'puppet',
     }
   }
@@ -236,7 +236,7 @@ class puppet::params {
 
   # DB package resources
   $mysql_conn_package = $::operatingsystem ? {
-    /(?i:RedHat|Centos|Scientific|Fedora)/  => 'ruby-mysql',
+    /(?i:RedHat|Centos|Scientific|Fedora|Linux)/  => 'ruby-mysql',
     default                                 => 'libmysql-ruby',
   }
 


### PR DESCRIPTION
68cb858 adds Oracle Linux Support.  The process name selector needed the Linux pattern to match OracleLinux.  The default process match was making nagios and puppi look for puppet instead of puppetd.

3b23d6a adds some detection to determine if Foreman parameters for puppet smart-proxies are available.  I realize this is a customization specifically for Foreman and may not be appropriate for merging.

I'm not sure if you want it or can reject it and accept the Oracle update above.
