### PR TITLE
Fix permissions regressions created by PR #67

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -739,6 +739,7 @@ class puppet (
   }
 
   file { 'ssl.dir':
+    ensure  => $puppet::manage_directory,
     path    => $ssl_dir,
     owner   => $puppet::config_file_owner,
     group   => $puppet::config_file_group,
@@ -748,7 +749,7 @@ class puppet (
   # The whole puppet configuration directory can be recursively overriden
   if $puppet::source_dir {
     file { 'puppet.dir':
-      ensure  => directory,
+      ensure  => $puppet::manage_directory,
       path    => $puppet::config_dir,
       require => Package['puppet'],
       notify  => $puppet::manage_service_autorestart,


### PR DESCRIPTION
Commit 3cbb6ba8ff06d8e2b68e00d44b86c3b6a8f64870 from PR #67 breaks `$log_dir` permissions and also tries to manage `$ssl_dir` as a file.

This PR fixes those.
