### PR TITLE
Permissions are REALLY wrong under `$ssldir`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -731,19 +731,11 @@ class puppet (
   file { 'puppet.log.dir':
     ensure  => $puppet::manage_directory,
     path    => $puppet::log_dir,
-    mode    => 0750,
+    mode    => '0750',
     owner   => $puppet::real_log_dir_owner,
     group   => $puppet::real_log_dir_group,
     require => Package['puppet'],
     audit   => $puppet::manage_audit,
-  }
-
-  file { 'ssl.dir':
-    ensure  => $puppet::manage_directory,
-    path    => $ssl_dir,
-    owner   => $puppet::config_file_owner,
-    group   => $puppet::config_file_group,
-    recurse => true,
   }
 
   # The whole puppet configuration directory can be recursively overriden


### PR DESCRIPTION
Commit 3cbb6ba8ff06d8e2b68e00d44b86c3b6a8f64870 changes permissions recursively, exposing certificates and changing directories access rights in clients. After a run, clients are unable run properly.

Remove `$ssl_dir` handling and leave it to puppet's initial checks and defaults.
