### PR TITLE
Fix: ruby-sqlite3 does not exist on debian squeeze

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -293,7 +293,10 @@ class puppet::params {
 
   $sqlite_package = $::osfamily ? {
     /(?i:RedHat)/ => 'rubygem-sqlite3-ruby',
-    /Debian/      => 'ruby-sqlite3',
+    /Debian/      => $::lsbmajdistrelease ? {
+      6       => 'libsqlite3-ruby',
+      default => 'ruby-sqlite3',
+    },
     /Gentoo/      => 'dev-ruby/sqlite3',
     /(?i:SuSE)/   => $::operatingsystem ? {
         /(?:OpenSuSE)/ => 'rubygem-sqlite3',


### PR DESCRIPTION
On debian squeeze ruby-sqlite3 package does not exist. This pull request install libsqlite3-ruby' on debian 6.
