### PR TITLE
Move masterport directive to [main] block to allow to set agent port at the same time

### DIFF
--- a/templates/server/puppet.conf.erb
+++ b/templates/server/puppet.conf.erb
@@ -19,6 +19,7 @@
   privatekeydir = $ssldir/private_keys { group = service }
   hostprivkey = $privatekeydir/$certname.pem { mode = 640 }
 <% end -%>
+  masterport = <%= scope.lookupvar('puppet::port') %>
 
 <% if scope.lookupvar('puppet::params::major_version') == "0.2" -%># [puppet]<% else -%># [user]<% end %>
 
@@ -38,7 +39,6 @@
 <% end -%> 
 
 <% if scope.lookupvar('puppet::params::major_version') == "0.2" -%>[puppetmasterd]<% else -%>[master]<% end %>
-  masterport = <%= scope.lookupvar('puppet::port') %>
 <% if scope.lookupvar('puppet::bindaddress') != '' -%>
   bindaddress = <%= scope.lookupvar('puppet::bindaddress') %>
 <% end -%>


### PR DESCRIPTION
Move masterport directive to [main] block to allow to set agent port at the same time.
Fix for #83.
