### PR TITLE
Added the access to the Environments list, needed to import environments...

### DIFF
--- a/templates/server/auth.conf.erb
+++ b/templates/server/auth.conf.erb
@@ -68,6 +68,11 @@ auth no
 method find, search
 allow <%= scope.lookupvar('puppet::server') %>
 
+# Access to Environments list, needed to import environments in Foreman
+path /v2.0/environments
+method find
+allow *
+
 # this one is not strictly necessary, but it has the merit
 # to show the default policy which is deny everything else
 path /


### PR DESCRIPTION
... in Foreman

Without this configuration import of new environments will fail on Foreman (or other ENC).
