### PR TITLE
adjust monitor conditional to test if $puppet::monitor == true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -851,7 +851,7 @@ class puppet (
 
 
   ### Service monitoring, if enabled ( monitor => true )
-  if $puppet::monitor_tool and $puppet::runmode == 'service' {
+  if $puppet::monitor == true and $puppet::monitor_tool and $puppet::runmode == 'service' {
     if $puppet::bool_listen == true {
       monitor::port { "puppet_${puppet::protocol}_${puppet::port_listen}":
         protocol => $puppet::protocol,


### PR DESCRIPTION
Per my comment: https://github.com/example42/puppet-puppet/issues/105#issuecomment-83088968.  Not sure if you want this or think it's wise, I just don't understand the logic of only testing if the monitor tool has been specified.