### PR TITLE
Future parser not allowing empty string on provider

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,7 +13,7 @@ class puppet::server inherits puppet {
     ensure   => $::puppet::manage_package_server,
     name     => $::puppet::package_server,
     notify   => $::puppet::manage_service_server_autorestart,
-    provider => $::puppet::package_provider,
+    provider => $::puppet::real_package_provider,
   }
 
   service { 'puppet_server':


### PR DESCRIPTION
The future parser causes puppet to stop applying because of an empty string of provider in the package definition.

`Parameter provider failed on Package[puppet_server]: Invalid package provider '' at /etc/puppet/modules/example42/puppet/manifests/server.pp:12`

Since variable `$real_package_provider` is introduced. it should be used.